### PR TITLE
Modify the sending time from 250ms to 1500ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,28 @@ No WhatsApp Web abra o console do Browser
 Cole o código no console e aperte Enter
 
 Pronto
+
+---
+
+# SendScriptWhatsApp
+
+Code to send the entire script of Shrek or Bee Movie to your friends or WhatsApp groups.
+
+## Usage
+
+Open [shrekSendScript.js](https://github.com/Matt-Fontes/SendScriptWhatsApp/blob/main/shrekSendScript.js)
+Or
+Open [beeMovieSendScript.js](https://github.com/Matt-Fontes/SendScriptWhatsApp/blob/main/beeMovieSendScript.js)
+
+Copy the entire content (click on raw -> ctrl+a -> ctrl+c)
+
+In WhatsApp Web, open the Browser console
+
+| ⚠️ Important Notice, in a recent update of Google Chrome, any script being pasted into the Console is being prevented.|
+|--|
+| ***To workaround this issue, the developer console expects to receive a textual confirmation by writing in the console: "allow-scripts"***|
+|After that, pasting and continuing the script execution will be allowed|
+
+Paste the code into the console and press Enter
+
+Ready

--- a/beeMovieSendScript.js
+++ b/beeMovieSendScript.js
@@ -16,7 +16,7 @@ async function enviarScript(scriptText){
 			(main.querySelector(`[data-testid="send"]`) || main.querySelector(`[data-icon="send"]`)).click();
 		}, 100);
 		
-		if(lines.indexOf(line) !== lines.length - 1) await new Promise(resolve => setTimeout(resolve, 250));
+		if(lines.indexOf(line) !== lines.length - 1) await new Promise(resolve => setTimeout(resolve, 1500));
 	}
 	
 	return lines.length;

--- a/shrekSendScript.js
+++ b/shrekSendScript.js
@@ -16,7 +16,7 @@ async function enviarScript(scriptText){
 			(main.querySelector(`[data-testid="send"]`) || main.querySelector(`[data-icon="send"]`)).click();
 		}, 100);
 		
-		if(lines.indexOf(line) !== lines.length - 1) await new Promise(resolve => setTimeout(resolve, 250));
+		if(lines.indexOf(line) !== lines.length - 1) await new Promise(resolve => setTimeout(resolve, 1500));
 	}
 	
 	return lines.length;


### PR DESCRIPTION
### Changes made:
Message sending time was adjusted from 250 ms to 1500 ms. This change was made to prevent WhatsApp from classifying messages as spam, which prevented the generation of notifications. After extensive testing, it was determined that an interval of 1500 ms was optimal to ensure effective triggering of sound notifications.

### In addition:
Translated the tutorial into English with the goal of broadening its accessibility to a global audience.