### PR TITLE
Update button selector for sending messages

### DIFF
--- a/shrekSendScript.js
+++ b/shrekSendScript.js
@@ -13,7 +13,7 @@ async function enviarScript(scriptText){
 		textarea.dispatchEvent(new Event('change', {bubbles: true}));
 	
 		setTimeout(() => {
-			(main.querySelector(`[data-testid="send"]`) || main.querySelector(`[data-icon="send"]`)).click();
+			(main.querySelector(`button[aria-label="Enviar"]`) || main.querySelector(`button[aria-label="Enviar"]`)).click();
 		}, 100);
 		
 		if(lines.indexOf(line) !== lines.length - 1) await new Promise(resolve => setTimeout(resolve, 250));


### PR DESCRIPTION
WhatsApp Web updated, and when searching for the "send" element, it couldn't find it; at least, that's how it worked for me.